### PR TITLE
Jcn 295 api get validation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Added
+- Add new functionality `async postGetValidation()`
+
+
 ## [3.0.0] - 2020-06-15
 ### Changed
 - API upgraded to v5 (`api-session` validates locations) (**BREAKING CHANGE**)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ## Added
-- Add new functionality `async postGetValidation()`
+- Add new functionality `async postGetValidate()`
 
 
 ## [3.0.0] - 2020-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ## Added
-- Add new functionality `async postGetValidate()`
+- `postGetValidate` method to validate registry after getting it
 
 
 ## [3.0.0] - 2020-06-15

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class MyApiGet extends ApiGet {
 	 * Validates the record getted from DB before format.
 	 * @param {object} The record in DB
 	 **/
-	async postGetValidation({name}) {
+	async postGetValidate({name}) {
 
 		if(name !== 'bar') {
 			this.setCode(403);

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ class MyApiGet extends ApiGet {
 	 * Validates the record getted from DB before format.
 	 * @param {Object} The record in DB
 	 **/
-	async postGetValidate({name}) {
+	async postGetValidate({ name }) {
 
-		if(name !== 'bar') {
+		if(name === FORBIDDEN_NAME) {
 			this.setCode(403);
 			throw new Error('Forbidden name');
 		}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ class MyApiGet extends ApiGet {
 		};
 	}
 
+	/**
+	 * Validates the record getted from DB before format.
+	 * @param {object} The record in DB
+	 **/
+	async postGetValidation({name}) {
+
+		if(name !== 'bar') {
+			this.setCode(403);
+			throw new Error('Forbidden name');
+		}
+	}
+
 }
 
 module.exports = MyApiGet;

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class MyApiGet extends ApiGet {
 
 	/**
 	 * Validates the record getted from DB before format.
-	 * @param {object} The record in DB
+	 * @param {Object} The record in DB
 	 **/
 	async postGetValidate({name}) {
 

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -43,19 +43,12 @@ class ApiGet extends API {
 
 		[this.record] = record;
 
-		await this.postGetValidate(this.record);
+		if(this.postGetValidate)
+			await this.postGetValidate(this.record);
 
 		const response = this.format ? await this.format(this.record) : this.record;
 
 		this.setBody(response);
-	}
-
-	/**
-	 * Validates the record getted from DB before format.
-	 * @param {Object} record
-	 */
-	async postGetValidate(record) {
-		return record;
 	}
 
 	_parseEndpoint() {

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -43,14 +43,14 @@ class ApiGet extends API {
 
 		[this.record] = record;
 
-		await this.postGetValidation(this.record);
+		await this.postGetValidate(this.record);
 
 		const response = this.format ? await this.format(this.record) : this.record;
 
 		this.setBody(response);
 	}
 
-	async postGetValidation(record) {
+	async postGetValidate(record) {
 		return record;
 	}
 

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -41,9 +41,17 @@ class ApiGet extends API {
 				});
 		}
 
-		const response = this.format ? await this.format(record[0]) : record[0];
+		[this.record] = record;
+
+		await this.postGetValidation(this.record);
+
+		const response = this.format ? await this.format(this.record) : this.record;
 
 		this.setBody(response);
+	}
+
+	async postGetValidation(record) {
+		return record;
 	}
 
 	_parseEndpoint() {

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -50,6 +50,10 @@ class ApiGet extends API {
 		this.setBody(response);
 	}
 
+	/**
+	 * Validates the record getted from DB before format.
+	 * @param {Object} record
+	 */
 	async postGetValidate(record) {
 		return record;
 	}

--- a/tests/api-get.js
+++ b/tests/api-get.js
@@ -427,7 +427,7 @@ describe('ApiGet', () => {
 					};
 				}
 
-				async postGetValidation({ foo }) {
+				async postGetValidate({ foo }) {
 
 					if(foo !== 'bar') {
 						this.setCode(403);
@@ -489,7 +489,7 @@ describe('ApiGet', () => {
 					};
 				}
 
-				async postGetValidation({ foo }) {
+				async postGetValidate({ foo }) {
 
 					if(foo !== 'bar') {
 						this.setCode(403);


### PR DESCRIPTION
**Link al ticket** 
https://fizzmod.atlassian.net/browse/JCN-295#icft=JCN-295

**Descripción del requerimiento**
Se require un método `postGetValidate` para validar el record obtenido de la base de datos. Esto es, por ejemplo, si se gettea un elemento de la base pero al analizar el campo `locations` el cliente no tiene acceso a esas `locations`, entonces se puede settear un comportamiento en dicho validate, por ejemplo, lanzar un 404 o loggear un mensaje. 

Adicionalmente ser require como atributo a `recordId`