### PR TITLE
JCN 400 add id validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 ### Added
 - Struct validation for path id
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Struct validation for path id
+
 ## [4.0.1] - 2021-12-13
 ### Added
 - Typings build from JSDoc

--- a/README.md
+++ b/README.md
@@ -74,9 +74,32 @@ If you have for example, a get API for a sub-entity of one specific record, the 
 
 For example, the following endpoint: `/api/parent-entity/1/sub-entity/2`, will be a get of the sub-entity, and `parentEntity: '1'` will be set as a filter.
 
-❗# Path ID validation
+# ✔️ Path ID validation
 
-If ID received by path parameter is invalid, the API will return a 400 error.
-This validation will only be performed if the database driver has `idStruct` getter implemented.
-This validation is only applied over the main record ID.
-Eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`
+## Default behavior
+1. If received ID is invalid, the API will return a ***400*** error. 
+2. Only the main record id will be validated (eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`).
+3. This validation will only be performed if the database driver has `idStruct` getter implemented.
+
+❗In case you want to set a different behaviour or validation, you can do it by overriding the `validateId` method.
+
+**eg: Adding validation for parent `ids`**
+```javascript
+	validateId() {
+
+		Object.values(this.parents).forEach(parentId => {
+			struct('string&!empty')(parentId)
+		});
+
+		struct('objectId')(this.recordId)
+	}
+```
+## How to disable validation
+In case you want to disable the validation, you can do it also by overriding the `validateId` method.
+
+**eg:**
+```javascript
+	validateId() {
+		// Do nothing
+	}
+```

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ All methods are optional
 If you have for example, a get API for a sub-entity of one specific record, the parent will be automatically be added as a filter.
 
 For example, the following endpoint: `/api/parent-entity/1/sub-entity/2`, will be a get of the sub-entity, and `parentEntity: '1'` will be set as a filter.
+
+❗# Path ID validation
+
+If ID received by path parameter is invalid, the API will return a 400 error.
+This validation will only be performed if the database driver has `idStruct` getter implemented.
+This validation is only applied over the main record ID.
+Eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`

--- a/README.md
+++ b/README.md
@@ -68,18 +68,21 @@ module.exports = MyApiGet;
 
 All methods are optional
 
-# Get APIs with parents
+## Get APIs with parents
 
 If you have for example, a get API for a sub-entity of one specific record, the parent will be automatically be added as a filter.
 
 For example, the following endpoint: `/api/parent-entity/1/sub-entity/2`, will be a get of the sub-entity, and `parentEntity: '1'` will be set as a filter.
 
-# ✔️ Path ID validation
+## ✔️ Path ID validation
+Validation for path ID is available. By implementing `validateId()` method, you can make sure ID format is correct. If received ID is invalid, the API will return a ***400*** error by default and no request will be made to database.
 
-## Default behavior
-1. If received ID is invalid, the API will return a ***400*** error. 
-2. Only the main record id will be validated (eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`).
-3. This validation will only be performed if the database driver has `idStruct` getter implemented.
+### Default behavior
+1. This validation will only be performed if database driver has `idStruct` getter implemented.
+2. If received ID is invalid, the API will return a ***400*** error. 
+3. Validation applies only to main record ID (eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`).
+
+### Customization
 
 ❗In case you want to set a different behaviour or validation, you can do it by overriding the `validateId` method.
 
@@ -94,7 +97,8 @@ For example, the following endpoint: `/api/parent-entity/1/sub-entity/2`, will b
 		struct('objectId')(this.recordId)
 	}
 ```
-## How to disable validation
+
+#### How to disable validation
 In case you want to disable the validation, you can do it also by overriding the `validateId` method.
 
 **eg:**

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Validation for path ID is available. By implementing `validateId()` method, you 
 ```
 
 #### How to disable validation
-In case you want to disable the validation, you can do it also by overriding the `validateId` method.
+In case database driver has an `idsStruct` defined and you want to disable validation, you can do it by overriding the `validateId` method.
 
 **eg:**
 ```javascript

--- a/README.md
+++ b/README.md
@@ -75,16 +75,15 @@ If you have for example, a get API for a sub-entity of one specific record, the 
 For example, the following endpoint: `/api/parent-entity/1/sub-entity/2`, will be a get of the sub-entity, and `parentEntity: '1'` will be set as a filter.
 
 ## ✔️ Path ID validation
-Validation for path ID is available. By implementing `validateId()` method, you can make sure ID format is correct. If received ID is invalid, the API will return a ***400*** error by default and no request will be made to database.
+The `ID` in the `pathParameters` can be validated if the database needs it in order to avoid problems. If this feature is active, the statusCode for this kind of error will be `400`. This validation has a default behavior (Model version 6.3.0 or higher is needed), and can also be customized for specific needs.
 
 ### Default behavior
-1. This validation will only be performed if database driver has `idStruct` getter implemented.
-2. If received ID is invalid, the API will return a ***400*** error. 
-3. Validation applies only to main record ID (eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`).
+1. The ID will not be validated unless the database driver has `idStruct` method implemented.
+2. Validation applies only to main record ID (eg: For `/api/parent-entity/1/sub-entity/2` the ID validation will be applied only to `2`).
 
 ### Customization
 
-❗In case you want to set a different behaviour or validation, you can do it by overriding the `validateId` method.
+❗In case you want to set a different behavior or validation, you can do it by overriding the `validateId` method.
 
 **eg: Adding validation for parent `ids`**
 ```javascript
@@ -99,7 +98,7 @@ Validation for path ID is available. By implementing `validateId()` method, you 
 ```
 
 #### How to disable validation
-In case database driver has an `idsStruct` defined and you want to disable validation, you can do it by overriding the `validateId` method.
+In case database driver has an `idStruct` defined and you want to disable validation, you can do it by overriding the `validateId` method.
 
 **eg:**
 ```javascript

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -24,10 +24,16 @@ module.exports = class ApiGet extends API {
 
 		this._validateModel();
 
-		if(this.model.idStruct)
-			this.model.idStruct(this.recordId);
+		await this.validateId();
 
 		return this.postValidate();
+	}
+
+	async validateId() {
+		if(this.model.getIdStruct) {
+			const idStruct = await this.model.getIdStruct(this.recordId);
+			idStruct(this.recordId);
+		}
 	}
 
 	/**

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -36,7 +36,14 @@ module.exports = class ApiGet extends API {
 	 */
 	async validateId() {
 
-		const idStruct = await this.model.getIdStruct();
+		let idStruct;
+
+		try {
+			idStruct = await this.model.getIdStruct();
+		} catch(error) {
+			this.setCode(500);
+			throw error;
+		}
 
 		if(idStruct)
 			idStruct(this.recordId);

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -29,11 +29,17 @@ module.exports = class ApiGet extends API {
 		return this.postValidate();
 	}
 
+	/**
+	 * Validates if path ID type is valid.
+	 * Validation will only be performed if database driver has `idStruct` getter implemented.
+	 * @returns {void}
+	 */
 	async validateId() {
-		if(this.model.getIdStruct) {
-			const idStruct = await this.model.getIdStruct(this.recordId);
+
+		const idStruct = await this.model.getIdStruct();
+
+		if(idStruct)
 			idStruct(this.recordId);
-		}
 	}
 
 	/**

--- a/lib/api-get.js
+++ b/lib/api-get.js
@@ -21,7 +21,11 @@ module.exports = class ApiGet extends API {
 	async validate() {
 
 		this._parseEndpoint();
+
 		this._validateModel();
+
+		if(this.model.idStruct)
+			this.model.idStruct(this.recordId);
 
 		return this.postValidate();
 	}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
     "sinon": "^12.0.1",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "@janiscommerce/superstruct": "^1.2.0"
   },
   "files": [
     "lib/",
@@ -39,7 +40,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "@janiscommerce/api": "^6.4.2",
-    "@janiscommerce/superstruct": "^1.2.0"
+    "@janiscommerce/api": "^6.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "@janiscommerce/api": "^6.4.2"
+    "@janiscommerce/api": "^6.4.2",
+    "@janiscommerce/superstruct": "^1.2.0"
   }
 }

--- a/tests/api-get.js
+++ b/tests/api-get.js
@@ -16,6 +16,9 @@ describe('ApiGet', () => {
 	});
 
 	class Model {
+		async getIdStruct() {
+			return undefined;
+		}
 	}
 
 	const modelPath = path.join(process.cwd(), process.env.MS_PATH || '', 'models', 'some-entity');
@@ -59,18 +62,28 @@ describe('ApiGet', () => {
 			await assert.rejects(() => apiGet.validate(), ApiGetError);
 		});
 
-		it('Should validate if a valid model and ID is passed', async () => {
+		it('Should reject if model fails on getting idStruct', async () => {
+
+			sinon.restore();
+			class Model2 {
+				async getIdStruct() {
+					return struct('objectId');
+				}
+			}
+
+			mockRequire(modelPath, Model2);
+
+			sinon.stub(Model2.prototype, 'getIdStruct')
+				.rejects(new Error('Internal Error'));
 
 			const apiGet = new ApiGet();
 			apiGet.endpoint = '/some-entity/10';
 			apiGet.pathParameters = ['10'];
 
-			const validation = await apiGet.validate();
-
-			assert.strictEqual(validation, true);
+			await assert.rejects(apiGet.validate(), { message: 'Internal Error' });
 		});
 
-		it('Should validate if a valid ID is passed', async () => {
+		it('Should reject if invalid ID is passed', async () => {
 
 			sinon.restore();
 			class Model2 {
@@ -87,6 +100,46 @@ describe('ApiGet', () => {
 
 			await assert.rejects(apiGet.validate(), { message: 'Expected a value of type `objectId` but received `"10"`.' });
 		});
+
+		it('Should validate if a valid model and ID is passed', async () => {
+			mockRequire(modelPath, Model);
+			const apiGet = new ApiGet();
+			apiGet.endpoint = '/some-entity/10';
+			apiGet.pathParameters = ['10'];
+
+			const validation = await apiGet.validate();
+
+			assert.strictEqual(validation, true);
+		});
+
+		it('Should not reject if model Database driver has no idStruct defined', async () => {
+
+			mockRequire(modelPath, Model);
+
+			const apiGet = new ApiGet();
+			apiGet.endpoint = '/some-entity/10';
+			apiGet.pathParameters = ['10'];
+
+			assert.deepStrictEqual(await apiGet.validate(), true);
+		});
+
+		it('Should not reject if invalid parent ID is passed', async () => {
+
+			sinon.restore();
+			class Model2 {
+				async getIdStruct() {
+					return struct('objectId');
+				}
+			}
+
+			mockRequire(modelPath, Model2);
+
+			const apiGet = new ApiGet();
+			apiGet.endpoint = '/some-parent/10/some-entity/6282c2484f64bffff55bcd7c';
+			apiGet.pathParameters = ['10', '6282c2484f64bffff55bcd7c'];
+
+			assert.deepStrictEqual(await apiGet.validate(), true);
+		});
 	});
 
 	describe('Process', () => {
@@ -96,6 +149,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -129,6 +186,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -174,6 +235,10 @@ describe('ApiGet', () => {
 				async get() {
 					return [];
 				}
+
+				async getIdStruct() {
+					return undefined;
+				}
 			}
 
 			mockRequire(modelPath, MyModel);
@@ -208,6 +273,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -252,6 +321,11 @@ describe('ApiGet', () => {
 		it('Should throw an internal error if get fails', async () => {
 
 			mockRequire(modelPath, class MyModel {
+
+				async getIdStruct() {
+					return undefined;
+				}
+
 				async get() {
 					throw new Error('Some internal error');
 				}
@@ -273,6 +347,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -315,6 +393,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [dbRecord];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -370,6 +452,10 @@ describe('ApiGet', () => {
 				async get() {
 					return [dbRecord];
 				}
+
+				async getIdStruct() {
+					return undefined;
+				}
 			}
 
 			mockRequire(modelPath, MyModel);
@@ -403,6 +489,10 @@ describe('ApiGet', () => {
 			class MyModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 
@@ -470,6 +560,10 @@ describe('ApiGet', () => {
 				async get() {
 					return [dbRecord];
 				}
+
+				async getIdStruct() {
+					return undefined;
+				}
 			}
 
 			mockRequire(modelPath, MyModel);
@@ -526,6 +620,10 @@ describe('ApiGet', () => {
 				async get() {
 					return [dbRecord];
 				}
+
+				async getIdStruct() {
+					return undefined;
+				}
 			}
 
 			mockRequire(modelPath, MyModel);
@@ -566,6 +664,10 @@ describe('ApiGet', () => {
 				async get() {
 					return [];
 				}
+
+				async getIdStruct() {
+					return undefined;
+				}
 			}
 
 			mockRequire(modelPath, MyModel);
@@ -592,6 +694,10 @@ describe('ApiGet', () => {
 			class OtherEntityModel {
 				async get() {
 					return [];
+				}
+
+				async getIdStruct() {
+					return undefined;
 				}
 			}
 

--- a/tests/api-get.js
+++ b/tests/api-get.js
@@ -74,7 +74,7 @@ describe('ApiGet', () => {
 
 			sinon.restore();
 			class Model2 {
-				get idStruct() {
+				async getIdStruct() {
 					return struct('objectId');
 				}
 			}
@@ -609,5 +609,4 @@ describe('ApiGet', () => {
 			mockRequire.stop(modelPath);
 		});
 	});
-
 });

--- a/tests/api-get.js
+++ b/tests/api-get.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { struct } = require('@janiscommerce/superstruct');
 const assert = require('assert');
 const path = require('path');
 
@@ -67,6 +68,24 @@ describe('ApiGet', () => {
 			const validation = await apiGet.validate();
 
 			assert.strictEqual(validation, true);
+		});
+
+		it('Should validate if a valid ID is passed', async () => {
+
+			sinon.restore();
+			class Model2 {
+				get idStruct() {
+					return struct('objectId');
+				}
+			}
+
+			mockRequire(modelPath, Model2);
+
+			const apiGet = new ApiGet();
+			apiGet.endpoint = '/some-entity/10';
+			apiGet.pathParameters = ['10'];
+
+			await assert.rejects(apiGet.validate(), { message: 'Expected a value of type `objectId` but received `"10"`.' });
 		});
 	});
 

--- a/tests/api-get.js
+++ b/tests/api-get.js
@@ -101,6 +101,33 @@ describe('ApiGet', () => {
 			await assert.rejects(apiGet.validate(), { message: 'Expected a value of type `objectId` but received `"10"`.' });
 		});
 
+		it('Should use validation defined in extended API', async () => {
+
+			sinon.restore();
+			class Model2 {
+				async getIdStruct() {
+					return struct('objectId');
+				}
+			}
+
+			class TestApi extends ApiGet {
+				async getIdStruct() {
+					return struct('string');
+				}
+			}
+
+			mockRequire(modelPath, Model2);
+			mockRequire(modelPath, TestApi);
+
+			const apiGet = new TestApi();
+			apiGet.endpoint = '/some-entity/10';
+			apiGet.pathParameters = ['10'];
+
+			const validation = await apiGet.validate();
+
+			assert.strictEqual(validation, true);
+		});
+
 		it('Should validate if a valid model and ID is passed', async () => {
 			mockRequire(modelPath, Model);
 			const apiGet = new ApiGet();


### PR DESCRIPTION
[Historia](https://fizzmod.atlassian.net/browse/JCN-400)
[Subtarea](https://fizzmod.atlassian.net/browse/JCN-400)

### Descripción del requerimiento
Se necesita que en el package de [GitHub - janis-commerce/api-get: A package to handle JANIS Views Get APIs](https://github.com/janis-commerce/api-get)  durante la fase de validate chequee que en el modelo de la entidad a gettear exista datos en el getter de idStruct , y si existe la función lo usé para validar el id que llega via pathParams , en caso de fallar, la API no debe seguir y arrojar un error 400.

Recordar que el getter, devuelve una función struct lista para aplicar. Esta va a validar que el id ingresante corresponda al requerido por la base.

Si no existen datos del getter, es decir no existe la función, no hay necesidad de validar nada.

### Datos a tener en cuenta
El metodo devuelto por el paquete Model es asincrono. Ese desarrollo se encuentra [acá](https://fizzmod.atlassian.net/browse/JCN-396)

![image](https://user-images.githubusercontent.com/40437300/169896848-8b902095-161e-4dcd-bde6-a62a5d3d223a.png)
![image](https://user-images.githubusercontent.com/40437300/169897443-434ae588-893c-4544-84eb-0936eab3172f.png)
